### PR TITLE
Add v5 deck-code format: high copy counts, SP cards, compact encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-15
+
+### Added
+
+- **High Copy-Count Support (Version 5)**: A single card may now exceed the previous count ceilings (12 in the main deck, 3 in the sideboard). This supports cards such as **Spiderling** (`VEN-097`), whose rules text allows any number of copies. A deck is encoded as Version 5 only when a card actually exceeds those ceilings.
+- **Sparse count encoding**: Version 5 sections list only the copy-counts that actually occur (most copies first) instead of walking a fixed range, keeping high-copy codes compact.
+- **Deck-level prefix bit**: A Version 5 code carries one bit indicating whether the deck uses any `R`/`SP` card. All-normal decks (the common high-copy case, e.g. Spiderling) omit the per-card flag byte entirely, making those codes ~25% shorter (e.g. a 40-card Spiderling deck drops from 133 to 100 characters).
+- **`SP` Special-Card Prefix (Version 5)**: Card numbers may carry an `SP` (special) prefix, e.g. `VEN-SP1` / `VEN-SP1a`. `SP` is a third value (`0x02`) on the number-prefix flag byte, parallel to `R` (runes), independent of the variant suffix. Special numbers are variable-width (`SP1`, not `SP01`). Any deck containing an `SP` card encodes as Version 5.
+- **Loud rejection of unknown prefixes**: The Version 5 decoder now throws on an unrecognised number-prefix flag instead of silently treating it as a normal card, so future additions fail safe on older decoders.
+- **Test suite**: Added a `node:test` suite (`npm test`) with committed golden vectors locking backward compatibility and the v5 wire format (both high-copy and `SP` cases, cross-checked against an independent encoder).
+
+### Changed
+
+- Decks with a card above the count ceilings (`> 12` main / `> 3` sideboard) or containing an `SP` special card now encode as Version 5. All other decks continue to encode as Version 3 or 4, byte-for-byte identical to previous releases.
+
+### Compatibility
+
+- ✅ Can decode Version 1, 2, 3, and 4 codes — unchanged.
+- ✅ Decks that fit the v1–4 ceilings still encode to byte-identical strings (verified by golden vectors).
+- ❌ Version 5 codes require an updated library; older libraries reject them with an `Unsupported version` error rather than misreading them.
+
+---
+
 ## [1.3.0] - 2026-07-01
 
 ### Added
@@ -94,6 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date       | Key Changes                                              |
 | ------- | ---------- | -------------------------------------------------------- |
+| 1.4.0   | 2026-07-15 | High copy-count support (Version 5, sparse encoding)     |
 | 1.3.0   | 2026-07-01 | VEN and RAD set identifiers                              |
 | 1.2.0   | 2026-03-04 | Rune card support (R## format), UNL set                  |
 | 1.1.0   | 2026-01-10 | Chosen champion support, alternative signed card suffix  |

--- a/README.md
+++ b/README.md
@@ -16,13 +16,23 @@ These strings can be used to share decks across Riftbound TCG applications and t
 
 ## Cards & Decks
 
-Every Riftbound TCG card has a corresponding card code. Card codes are comprised of a three-character set identifier, a three-digit card number, and an optional single-character variant suffix.
+Every Riftbound TCG card has a corresponding card code. Card codes are comprised of a three-character set identifier, a card number with an optional prefix (`R` for runes, `SP` for special cards), and an optional single-character variant suffix.
 
 ```
 OGN-007a
 │   │  └ variant - a
 │   └ card number - 007
 └ set - OGN
+```
+
+The card number may carry an optional prefix on its own axis (independent of the variant suffix):
+
+```
+VEN-SP1a
+│   │ │└ variant - a
+│   │ └ card number - 1
+│   └ number prefix - SP (special)
+└ set - VEN
 ```
 
 The deck code library accepts a Riftbound deck as a list of `Card` objects. This is simply the card code and an associated integer for the number of occurrences of the card in the deck.
@@ -39,6 +49,7 @@ All encodings begin with 4 bits for format and 4 bits for version.
 | 1      | 2       | November 20, 2025 | Adds sideboard support.                                                   |
 | 1      | 3       | January 10, 2026  | Adds chosen champion support.                                             |
 | 1      | 4       | March 4, 2026     | Adds rune-card support with a normal/rune flag before each card number.   |
+| 1      | 5       | July 15, 2026     | Adds high copy-count support (a single card may exceed the v1–4 count ceilings of main 12 / sideboard 3, via a sparse count encoding), `SP` special-card number-prefix support (flag byte `0x02`), and a deck-level prefix bit so all-normal decks omit per-card flag bytes. |
 
 The list of cards are then encoded according to the following scheme:
 
@@ -65,6 +76,30 @@ The list of cards are then encoded according to the following scheme:
 6. For Version 4 decks, each card number is preceded by a flag byte: `0x00` for a normal card number or `0x01` for an `R`-prefixed rune number.
 7. The resulting byte array is base32 encoded into a string.
 
+#### Version 5: high copy counts (sparse encoding)
+
+The v1–4 scheme walks _every_ count from a fixed maximum (12 main, 3 sideboard) down to 1, so a card cannot have more copies than that maximum. Some cards (e.g. **Spiderling**, whose rules text is _"Your deck can have any number of cards named Spiderling"_) may legally appear far more often. A deck is encoded as **Version 5** whenever any single card exceeds those ceilings (`> 12` copies in the main deck or `> 3` in the sideboard), or contains an `SP` special card; otherwise it still encodes as Version 3 or 4, byte-for-byte identical to earlier releases.
+
+A Version 5 code begins with a single **deck-level prefix bit** (one byte) immediately after the format/version byte:
+
+- `0` — the deck contains **no** `R` or `SP` cards, so card numbers are written **without** the per-card flag byte (a bare varint each). This is the common high-copy case (e.g. a Spiderling deck of ordinary cards) and avoids paying a flag byte on every card.
+- `1` — the deck contains at least one `R`/`SP` card, so **every** card number is preceded by its flag byte (`0x00`/`0x01`/`0x02`), exactly as in Version 4.
+
+Then, rather than walking a fixed count range, each Version 5 section writes only the copy-counts that actually occur, ordered most-copies first:
+
+- [how many distinct copy-counts occur in this section]
+  - [copy-count]
+  - [how many set/variant lists have this copy-count]
+    - [how many cards within this set/variant combination follow]
+    - [set]
+    - [variant]
+      - [flag byte, only if the deck prefix bit is `1`] [card number]
+      - [flag byte, only if the deck prefix bit is `1`] [card number]
+      - ...
+  - [repeat for the next copy-count, descending]
+
+Set/variant grouping and ordering are unchanged. The chosen champion follows the same prefix-bit convention. Because Version 5 is a new version number, libraries built before it reject v5 codes (see the version guard) rather than misreading them, and all Version 1–4 codes continue to decode unchanged.
+
 ### Set Identifiers
 
 Sets are mapped as follows:
@@ -78,6 +113,18 @@ Sets are mapped as follows:
 | 4                  | UNL      | Unleashed       |
 | 5                  | VEN      | Vendetta        |
 | 6                  | RAD      | Radiance        |
+
+### Number Prefix Identifiers
+
+The card number sits on its own axis (introduced in Version 4). Each card number is preceded by a flag byte identifying its prefix; the digits are stored as a varint, and the prefix and its zero-padding width are reconstructed on decode.
+
+| Flag byte | Prefix | Meaning | Number width on decode |
+| --------- | ------ | ------- | ---------------------- |
+| `0x00`    | (none) | Normal  | 3 (`001`)              |
+| `0x01`    | `R`    | Rune    | 2 (`R01`)              |
+| `0x02`    | `SP`   | Special | unpadded (`SP1`)       |
+
+> **Note:** The prefix is independent of the variant suffix, so `VEN-SP1a` (special number `1`, variant `a`) is valid. Prefixes are uppercase only (`R`, `SP`). Special numbers are variable-width, so `VEN-SP01` normalises to `VEN-SP1` on round-trip. The `SP` flag was added in Version 5; a deck containing any `SP` card encodes as Version 5.
 
 ### Variant Identifiers
 
@@ -200,9 +247,9 @@ const starDecode = getDeckFromCode(code, { signedSuffix: "*" });
 ### Important Notes
 
 - **No Game Rule Validation**: This library only encodes/decodes deck data. It does not validate Riftbound game rules (card limits, sideboard size, etc.). Validation should be done in your application.
-- **Card Counts**: Main deck supports counts 1-12 (for runes and standard cards). Sideboard only supports counts 1-3 (optimized for regular cards only).
-- **Format Versions**: New non-rune deck codes encode as Version 3. Decks containing `R`-prefixed rune card numbers encode as Version 4.
-- **Backward Compatibility**: Can decode Version 1, 2, 3, and 4 codes. Version 1 and 2 codes return `chosenChampion: undefined`.
+- **Card Counts**: In Versions 1–4, the main deck supports counts 1-12 and the sideboard 1-3. Version 5 lifts this ceiling for high-copy cards (e.g. Spiderling), supporting any number of copies of a single card.
+- **Format Versions**: New non-rune deck codes encode as Version 3. Decks containing `R`-prefixed rune card numbers encode as Version 4. Decks where a single card exceeds the count ceilings (`> 12` main / `> 3` sideboard), or that contain an `SP`-prefixed special card, encode as Version 5.
+- **Backward Compatibility**: Can decode Version 1, 2, 3, 4, and 5 codes. Version 1 and 2 codes return `chosenChampion: undefined`.
 
 ## Implementations
 
@@ -212,7 +259,7 @@ The TypeScript implementation in this repository is the reference implementation
 
 | Name               | Language   | Version\* | Maintainer      |
 | ------------------ | ---------- | --------- | --------------- |
-| RiftboundDeckCodes | TypeScript | 4         | PiltoverArchive |
+| RiftboundDeckCodes | TypeScript | 5         | PiltoverArchive |
 
 \*Version refers to the MAX_KNOWN_VERSION supported by the implementation.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Sets are mapped as follows:
 
 ### Number Prefix Identifiers
 
-The card number sits on its own axis (introduced in Version 4). Each card number is preceded by a flag byte identifying its prefix; the digits are stored as a varint, and the prefix and its zero-padding width are reconstructed on decode.
+The card number sits on its own axis (introduced in Version 4). A flag byte identifies its prefix; the digits are stored as a varint, and the prefix and its zero-padding width are reconstructed on decode. In **Version 4** the flag byte always precedes every card number. In **Version 5** it is present only when the deck-level prefix bit is `1` (i.e. the deck contains at least one `R`/`SP` card); all-normal v5 decks omit it entirely.
 
 | Flag byte | Prefix | Meaning | Number width on decode |
 | --------- | ------ | ------- | ---------------------- |
@@ -247,7 +247,7 @@ const starDecode = getDeckFromCode(code, { signedSuffix: "*" });
 ### Important Notes
 
 - **No Game Rule Validation**: This library only encodes/decodes deck data. It does not validate Riftbound game rules (card limits, sideboard size, etc.). Validation should be done in your application.
-- **Card Counts**: In Versions 1–4, the main deck supports counts 1-12 and the sideboard 1-3. Version 5 lifts this ceiling for high-copy cards (e.g. Spiderling), supporting any number of copies of a single card.
+- **Card Counts**: In Versions 1–4, the main deck supports counts 1-12 and the sideboard 1-3. Version 5 lifts this ceiling for high-copy cards (e.g. Spiderling), supporting any number of copies of a single card. Counts must be positive integers; `getCodeFromDeck` throws on a zero, negative, or non-integer count.
 - **Format Versions**: New non-rune deck codes encode as Version 3. Decks containing `R`-prefixed rune card numbers encode as Version 4. Decks where a single card exceeds the count ceilings (`> 12` main / `> 3` sideboard), or that contain an `SP`-prefixed special card, encode as Version 5.
 - **Backward Compatibility**: Can decode Version 1, 2, 3, 4, and 5 codes. Version 1 and 2 codes return `chosenChampion: undefined`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@piltoverarchive/riftbound-deck-codes",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@piltoverarchive/riftbound-deck-codes",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"typescript": "^5.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piltoverarchive/riftbound-deck-codes",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Encode and decode Riftbound TCG decks to/from shareable strings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "pretest": "npm run build",
+    "test": "node --test test/*.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/deckCode.ts
+++ b/src/deckCode.ts
@@ -286,10 +286,13 @@ function decodeDeckSection(
  *     per count (high -> low):
  *       [count] [numGroups]
  *         per set/variant group: [numCards] [set] [variant]
- *           per card: [flag: 0x00 normal | 0x01 rune] [cardNumber]
+ *           per card: when `flagged`, a prefix flag byte
+ *             (0x00 normal | 0x01 rune | 0x02 special) precedes the card
+ *             number varint; when not `flagged`, the bare card number varint.
  *
- * v5 always uses the rune flag byte (it is >= 4), so runes need no special
- * versioning here.
+ * `flagged` mirrors the deck-level prefix bit written by the caller
+ * (getCodeFromDeck): it is true only when the deck contains an R/SP card, so
+ * all-normal decks omit the per-card flag byte entirely.
  */
 function encodeDeckSectionSparse(deck: Deck, flagged: boolean): number[] {
   const bytes: number[] = [];
@@ -434,6 +437,17 @@ export function getCodeFromDeck(
   sideboard: Deck = [],
   chosenChampion?: string
 ): string {
+  // Reject malformed counts before any varint processing: a non-integer,
+  // zero, negative, or unsafe count would otherwise be silently truncated or
+  // wrapped by the bitwise varint encoder into a wrong (but valid-looking) code.
+  for (const card of [...mainDeck, ...sideboard]) {
+    if (!Number.isSafeInteger(card.count) || card.count < 1) {
+      throw new Error(
+        `Invalid card count for ${card.cardCode}: ${card.count}. Count must be a positive integer.`
+      );
+    }
+  }
+
   // Number-prefix axis: a per-card flag byte distinguishes normal (0x00),
   // rune "R" (0x01), and special "SP" (0x02) numbers. R and SP are disjoint
   // prefixes, so these checks never overlap.

--- a/src/deckCode.ts
+++ b/src/deckCode.ts
@@ -9,7 +9,7 @@ import type {
 import VarintTranslator from "./VarintTranslator";
 
 const FORMAT = 1;
-const VERSION = 4;
+const VERSION = 5;
 const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
 /**
@@ -90,7 +90,7 @@ function parseCardCode(cardCode: string): {
     );
   }
 
-  const match = rest.match(/^(R?\d+)([a-z*]?)$/);
+  const match = rest.match(/^((?:R|SP)?\d+)([a-z*]?)$/);
   if (!match) {
     throw new Error(
       `Invalid card code format: ${cardCode}. Expected format: SET-NUMBERvariant`
@@ -275,6 +275,153 @@ function decodeDeckSection(
 }
 
 /**
+ * Encodes a deck section using the Version 5 "sparse" scheme.
+ *
+ * Instead of walking every count from a fixed maximum down to 1 (v1-v4), v5
+ * lists only the copy-counts that actually occur, high to low. This lets a
+ * single card have an arbitrarily high copy count (e.g. "Spiderling") without
+ * the leading/gap zero bytes the fixed-walk scheme would emit. Layout:
+ *
+ *   [numDistinctCounts]
+ *     per count (high -> low):
+ *       [count] [numGroups]
+ *         per set/variant group: [numCards] [set] [variant]
+ *           per card: [flag: 0x00 normal | 0x01 rune] [cardNumber]
+ *
+ * v5 always uses the rune flag byte (it is >= 4), so runes need no special
+ * versioning here.
+ */
+function encodeDeckSectionSparse(deck: Deck, flagged: boolean): number[] {
+  const bytes: number[] = [];
+
+  // Distinct copy-counts present in this section, processed high -> low.
+  const counts = Array.from(
+    new Set(deck.filter((card) => card.count >= 1).map((card) => card.count))
+  ).sort((a, b) => b - a);
+
+  bytes.push(...VarintTranslator.GetVarint(counts.length));
+
+  for (const count of counts) {
+    bytes.push(...VarintTranslator.GetVarint(count));
+
+    const cards = deck.filter((card) => card.count === count);
+    const setVariantGroups = groupBySetAndVariant(cards);
+
+    bytes.push(...VarintTranslator.GetVarint(setVariantGroups.length));
+
+    for (const group of setVariantGroups) {
+      bytes.push(...VarintTranslator.GetVarint(group.cardNumbers.length));
+      bytes.push(group.set);
+      bytes.push(group.variant);
+
+      for (const cardNumber of group.cardNumbers) {
+        if (!flagged) {
+          // All-normal deck: no prefix flag byte, bare card-number varint.
+          bytes.push(...VarintTranslator.GetVarint(parseInt(cardNumber)));
+        } else if (cardNumber.startsWith("SP")) {
+          bytes.push(0x02); // Special flag
+          bytes.push(
+            ...VarintTranslator.GetVarint(parseInt(cardNumber.slice(2)))
+          );
+        } else if (cardNumber.startsWith("R")) {
+          bytes.push(0x01); // Rune flag
+          bytes.push(
+            ...VarintTranslator.GetVarint(parseInt(cardNumber.slice(1)))
+          );
+        } else {
+          bytes.push(0x00); // Normal card flag
+          bytes.push(...VarintTranslator.GetVarint(parseInt(cardNumber)));
+        }
+      }
+    }
+  }
+
+  return bytes;
+}
+
+/**
+ * Decodes a deck section written with the Version 5 "sparse" scheme.
+ * @param translator - The varint translator
+ * @param signedSuffix - The suffix to use for signed cards ('s' or '*')
+ */
+function decodeDeckSectionSparse(
+  translator: VarintTranslator,
+  signedSuffix: "s" | "*" = "s",
+  flagged: boolean = true
+): Deck {
+  const deck: Deck = [];
+
+  const numCounts = translator.PopVarint();
+
+  for (let i = 0; i < numCounts; i++) {
+    const count = translator.PopVarint();
+    const numGroups = translator.PopVarint();
+
+    for (let g = 0; g < numGroups; g++) {
+      const numCards = translator.PopVarint();
+      const set = translator.get(0);
+      const variant = translator.get(1);
+      translator.sliceAndSet(2);
+
+      const setCode = Object.entries(SET_MAP).find(
+        ([_, value]) => value === set
+      )?.[0];
+
+      // For signed cards (variant 2), use the signedSuffix option
+      let variantCode: string | undefined;
+      if (variant === 2) {
+        variantCode = signedSuffix;
+      } else {
+        variantCode = Object.entries(VARIANT_MAP).find(
+          ([_, value]) => value === variant
+        )?.[0];
+      }
+
+      if (!setCode) {
+        throw new Error(`Unknown set code: ${set}`);
+      }
+
+      for (let j = 0; j < numCards; j++) {
+        let cardNumberStr: string;
+        if (!flagged) {
+          // All-normal deck: no prefix flag byte precedes the card number.
+          const num = translator.PopVarint();
+          cardNumberStr = num.toString().padStart(3, "0");
+          deck.push({
+            cardCode: `${setCode}-${cardNumberStr}${variantCode || ""}`,
+            count,
+          });
+          continue;
+        }
+
+        const prefixFlag = translator.get(0);
+        translator.sliceAndSet(1);
+        const num = translator.PopVarint();
+
+        if (prefixFlag === 0x02) {
+          cardNumberStr = `SP${num}`; // special: unpadded, variable width
+        } else if (prefixFlag === 0x01) {
+          cardNumberStr = `R${num.toString().padStart(2, "0")}`;
+        } else if (prefixFlag === 0x00) {
+          cardNumberStr = num.toString().padStart(3, "0");
+        } else {
+          // Fail loudly on an unrecognised prefix rather than silently
+          // mis-decoding it as a normal card.
+          throw new Error(`Unknown number-prefix flag: ${prefixFlag}`);
+        }
+
+        deck.push({
+          cardCode: `${setCode}-${cardNumberStr}${variantCode || ""}`,
+          count,
+        });
+      }
+    }
+  }
+
+  return deck;
+}
+
+/**
  * Encodes a Riftbound deck into a shareable deck code
  * @param mainDeck - The main deck cards
  * @param sideboard - Optional sideboard cards (defaults to empty array)
@@ -287,27 +434,63 @@ export function getCodeFromDeck(
   sideboard: Deck = [],
   chosenChampion?: string
 ): string {
-  // Determine if any card has an R-prefix number
+  // Number-prefix axis: a per-card flag byte distinguishes normal (0x00),
+  // rune "R" (0x01), and special "SP" (0x02) numbers. R and SP are disjoint
+  // prefixes, so these checks never overlap.
   const hasRuneCode = (code: string) => {
     const { number } = parseCardCode(code);
     return number.startsWith("R");
+  };
+  const hasSpecialCode = (code: string) => {
+    const { number } = parseCardCode(code);
+    return number.startsWith("SP");
   };
   const needsV4 =
     mainDeck.some((c) => hasRuneCode(c.cardCode)) ||
     sideboard.some((c) => hasRuneCode(c.cardCode)) ||
     (chosenChampion !== undefined && hasRuneCode(chosenChampion));
-  const version = needsV4 ? 4 : 3;
+
+  // Two independent triggers require the v5 sparse scheme:
+  //  - a card exceeds the v1-v4 count ceilings (e.g. "Spiderling", any number
+  //    of copies), or
+  //  - a card uses the "SP" (special) number prefix, whose 0x02 flag older
+  //    decoders would silently mis-read as a normal card.
+  // Everything else keeps emitting v3/v4, byte-identical to prior releases.
+  const maxMain = mainDeck.reduce((m, c) => Math.max(m, c.count), 0);
+  const maxSide = sideboard.reduce((m, c) => Math.max(m, c.count), 0);
+  const needsV5 = maxMain > 12 || maxSide > 3;
+  const anySpecial =
+    mainDeck.some((c) => hasSpecialCode(c.cardCode)) ||
+    sideboard.some((c) => hasSpecialCode(c.cardCode)) ||
+    (chosenChampion !== undefined && hasSpecialCode(chosenChampion));
+
+  const version = needsV5 || anySpecial ? 5 : needsV4 ? 4 : 3;
+
+  // Only decks that actually contain an R/SP card need the per-card prefix
+  // flag byte. `flagged` is true exactly when some card carries a prefix; an
+  // all-normal deck (e.g. a high-copy Spiderling deck) sets it false and
+  // encodes bare card numbers, saving a byte per card. For v5 this is written
+  // as an explicit deck-level bit; for v3/v4 it is implied by the version
+  // (v4 always flags, v3 never does), so those codes are unaffected.
+  const flagged = needsV4 || anySpecial;
 
   const bytes: number[] = [];
 
   // Write format and version
   bytes.push((FORMAT << 4) | version);
 
-  // Encode main deck (counts 1-12)
-  bytes.push(...encodeDeckSection(mainDeck, 12, version));
+  if (version >= 5) {
+    // v5: one deck-level prefix bit, then sparse main + sideboard sections.
+    bytes.push(flagged ? 1 : 0);
+    bytes.push(...encodeDeckSectionSparse(mainDeck, flagged));
+    bytes.push(...encodeDeckSectionSparse(sideboard, flagged));
+  } else {
+    // Encode main deck (counts 1-12)
+    bytes.push(...encodeDeckSection(mainDeck, 12, version));
 
-  // Encode sideboard (counts 1-3 only, since sideboards can't have runes/battlefields)
-  bytes.push(...encodeDeckSection(sideboard, 3, version));
+    // Encode sideboard (counts 1-3 only, since sideboards can't have runes/battlefields)
+    bytes.push(...encodeDeckSection(sideboard, 3, version));
+  }
 
   // Encode chosen champion (version 3+)
   if (chosenChampion) {
@@ -327,10 +510,13 @@ export function getCodeFromDeck(
     bytes.push(0x01); // Champion present flag
     bytes.push(setValue);
     bytes.push(variantValue);
-    if (version >= 4 && number.startsWith("R")) {
+    if (flagged && number.startsWith("SP")) {
+      bytes.push(0x02); // Special flag
+      bytes.push(...VarintTranslator.GetVarint(parseInt(number.slice(2))));
+    } else if (flagged && number.startsWith("R")) {
       bytes.push(0x01); // Rune flag
       bytes.push(...VarintTranslator.GetVarint(parseInt(number.slice(1))));
-    } else if (version >= 4) {
+    } else if (flagged) {
       bytes.push(0x00); // Normal card flag
       bytes.push(...VarintTranslator.GetVarint(parseInt(number)));
     } else {
@@ -377,14 +563,37 @@ export function getDeckFromCode(
     );
   }
 
-  // Decode main deck (counts 1-12)
-  const mainDeck = decodeDeckSection(translator, 12, signedSuffix, version);
+  // For v5, a deck-level prefix bit follows the version byte and selects whether
+  // card numbers carry a per-card flag. For v3/v4 the convention is implied by
+  // the version (v4 flags, v3 does not).
+  let flagged: boolean;
+  if (version >= 5) {
+    const prefixFlag = translator.get(0);
+    translator.sliceAndSet(1);
+    if (prefixFlag > 1) {
+      throw new Error(`Unsupported deck prefix flag: ${prefixFlag}`);
+    }
+    flagged = prefixFlag === 1;
+  } else {
+    flagged = version >= 4;
+  }
 
-  // Decode sideboard (counts 1-3 only)
-  // Version 1 codes don't have sideboard section, version 2+ do
+  let mainDeck: Deck;
   let sideboard: Deck = [];
-  if (version >= 2) {
-    sideboard = decodeDeckSection(translator, 3, signedSuffix, version);
+
+  if (version >= 5) {
+    // v5: sparse scheme (both main deck and sideboard)
+    mainDeck = decodeDeckSectionSparse(translator, signedSuffix, flagged);
+    sideboard = decodeDeckSectionSparse(translator, signedSuffix, flagged);
+  } else {
+    // Decode main deck (counts 1-12)
+    mainDeck = decodeDeckSection(translator, 12, signedSuffix, version);
+
+    // Decode sideboard (counts 1-3 only)
+    // Version 1 codes don't have sideboard section, version 2+ do
+    if (version >= 2) {
+      sideboard = decodeDeckSection(translator, 3, signedSuffix, version);
+    }
   }
 
   // Decode chosen champion (version 3+ only)
@@ -399,14 +608,20 @@ export function getDeckFromCode(
       translator.sliceAndSet(2);
 
       let cardNumberStr: string;
-      if (version >= 4) {
-        const isRune = translator.get(0);
+      if (flagged) {
+        const prefixFlag = translator.get(0);
         translator.sliceAndSet(1);
         const num = translator.PopVarint();
-        if (isRune === 0x01) {
+        if (prefixFlag === 0x02) {
+          cardNumberStr = `SP${num}`; // special: unpadded, variable width
+        } else if (prefixFlag === 0x01) {
           cardNumberStr = `R${num.toString().padStart(2, "0")}`;
-        } else {
+        } else if (prefixFlag === 0x00) {
           cardNumberStr = num.toString().padStart(3, "0");
+        } else {
+          throw new Error(
+            `Unknown number-prefix flag in champion: ${prefixFlag}`
+          );
         }
       } else {
         const num = translator.PopVarint();

--- a/test/deckCode.test.js
+++ b/test/deckCode.test.js
@@ -1,0 +1,454 @@
+// Behavior tests for the public deck-code interface (getCodeFromDeck / getDeckFromCode).
+// Run against the COMPILED dist — the exact artifact that ships to npm.
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { getCodeFromDeck, getDeckFromCode } = require("../dist/index.js");
+const golden = require("./fixtures/golden.json");
+
+// --- helpers (operate only on the public wire format / public API) ---
+const B32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+// Read the format/version nibble straight out of the code's first byte.
+function versionOf(code) {
+  const firstByte = (B32.indexOf(code[0]) << 3) | (B32.indexOf(code[1]) >> 2);
+  return firstByte & 0x0f;
+}
+function formatOf(code) {
+  const firstByte = (B32.indexOf(code[0]) << 3) | (B32.indexOf(code[1]) >> 2);
+  return (firstByte >> 4) & 0x0f;
+}
+
+// Base32-encode arbitrary bytes (matches the library alphabet) — used to craft
+// codes the library never emits (e.g. a future version byte).
+function bytesToBase32(bytes) {
+  let result = "";
+  let buffer = 0;
+  let bitsLeft = 0;
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte;
+    bitsLeft += 8;
+    while (bitsLeft >= 5) {
+      bitsLeft -= 5;
+      result += B32[(buffer >> bitsLeft) & 0x1f];
+    }
+  }
+  if (bitsLeft > 0) {
+    buffer <<= 5 - bitsLeft;
+    result += B32[buffer & 0x1f];
+  }
+  return result;
+}
+
+// Decode base32 back to bytes (to inspect the deck-level prefix bit at byte 1).
+function base32ToBytes(str) {
+  const bytes = [];
+  let buffer = 0;
+  let bitsLeft = 0;
+  for (const ch of str) {
+    buffer = (buffer << 5) | B32.indexOf(ch.toUpperCase());
+    bitsLeft += 5;
+    if (bitsLeft >= 8) {
+      bitsLeft -= 8;
+      bytes.push((buffer >> bitsLeft) & 0xff);
+    }
+  }
+  return bytes;
+}
+// The v5 prefix bit lives in the second byte (0 = all-normal, 1 = has R/SP).
+const prefixBitOf = (code) => base32ToBytes(code)[1];
+
+// Order-insensitive deck comparison shape (encode/decode order is deterministic
+// but not required to match input order).
+const normDeck = (deck) =>
+  [...(deck || [])].sort(
+    (a, b) => a.cardCode.localeCompare(b.cardCode) || a.count - b.count
+  );
+const shape = (r) => ({
+  mainDeck: normDeck(r.mainDeck),
+  sideboard: normDeck(r.sideboard),
+  champion: r.chosenChampion ?? null,
+});
+
+const oneCard = (cardCode, count) => [{ cardCode, count }];
+
+// ---------------------------------------------------------------------------
+// (a) BACKWARD COMPATIBILITY — locked golden vectors from the 1.3.0 build.
+//     These decks (max <=12 main / <=3 side) MUST keep emitting v3/v4 with the
+//     old scheme, byte-identical, and their codes must decode identically.
+// ---------------------------------------------------------------------------
+test.describe("backward compatibility (1.3.0 golden vectors)", () => {
+  for (const g of golden) {
+    test.describe(g.name, () => {
+      test("encodes to the exact recorded 1.3.0 string", () => {
+        const code = getCodeFromDeck(
+          g.input.mainDeck,
+          g.input.sideboard,
+          g.input.chosenChampion
+        );
+        assert.equal(code, g.code);
+      });
+      test("stays version 3 or 4 (never v5)", () => {
+        assert.equal(formatOf(g.code), 1);
+        assert.ok(
+          versionOf(g.code) === 3 || versionOf(g.code) === 4,
+          `expected v3/v4, got v${versionOf(g.code)}`
+        );
+      });
+      test("decodes to the exact recorded deck", () => {
+        assert.deepEqual(shape(getDeckFromCode(g.code)), shape(g.decoded));
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (b) BOUNDARY — v5 only triggers when a section actually needs >12 / >3.
+// ---------------------------------------------------------------------------
+test.describe("version-selection boundary", () => {
+  test("12 copies of a main card stays v3", () => {
+    assert.equal(versionOf(getCodeFromDeck(oneCard("OGN-004", 12))), 3);
+  });
+  test("13 copies of a main card triggers v5", () => {
+    assert.equal(versionOf(getCodeFromDeck(oneCard("OGN-004", 13))), 5);
+  });
+  test("3 copies of a sideboard card stays v3", () => {
+    assert.equal(
+      versionOf(getCodeFromDeck(oneCard("OGN-004", 1), oneCard("OGN-050", 3))),
+      3
+    );
+  });
+  test("4 copies of a sideboard card triggers v5", () => {
+    assert.equal(
+      versionOf(getCodeFromDeck(oneCard("OGN-004", 1), oneCard("OGN-050", 4))),
+      5
+    );
+  });
+  test("12 copies + a rune stays v4 (not v5)", () => {
+    const code = getCodeFromDeck([
+      { cardCode: "OGN-004", count: 12 },
+      { cardCode: "SFD-R02", count: 3 },
+    ]);
+    assert.equal(versionOf(code), 4);
+  });
+  test("13 copies + a rune becomes v5", () => {
+    const code = getCodeFromDeck([
+      { cardCode: "OGN-004", count: 13 },
+      { cardCode: "SFD-R02", count: 3 },
+    ]);
+    assert.equal(versionOf(code), 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) v5 WIRE FORMAT — locked against an INDEPENDENT sparse-bucketed oracle
+//     (a separate reimplementation, not this library). Agreement here means two
+//     implementations produce the identical bytes — protects downstream ports.
+// ---------------------------------------------------------------------------
+test.describe("v5 wire format (independent oracle vectors)", () => {
+  const vectors = [
+    { name: "13x VEN-097", main: oneCard("VEN-097", 13), side: [], code: "CUAACDIBAECQAYIAAA" },
+    { name: "40x VEN-097", main: oneCard("VEN-097", 40), side: [], code: "CUAACKABAECQAYIAAA" },
+    {
+      name: "20x VEN-097 + sideboard 4x VEN-050",
+      main: oneCard("VEN-097", 20),
+      side: oneCard("VEN-050", 4),
+      code: "CUAACFABAECQAYIBAQAQCBIAGIAA",
+    },
+    // count crosses the 128 varint boundary (first 2-byte count) — locks the
+    // one field v5 newly writes as an explicit varint against the oracle.
+    { name: "128x VEN-097 (2-byte count)", main: oneCard("VEN-097", 128), side: [], code: "CUAADAABAEAQKADBAAAA" },
+    { name: "200x VEN-097 (2-byte count)", main: oneCard("VEN-097", 200), side: [], code: "CUAADSABAEAQKADBAAAA" },
+  ];
+  for (const v of vectors) {
+    test(`${v.name} encodes to the oracle string`, () => {
+      assert.equal(getCodeFromDeck(v.main, v.side), v.code);
+    });
+    test(`${v.name} is version 5`, () => {
+      assert.equal(versionOf(v.code), 5);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (c/d/e/g) ROUND-TRIP — encode -> decode -> deep-equal for v5 decks.
+// ---------------------------------------------------------------------------
+test.describe("v5 round-trips", () => {
+  const cases = [
+    {
+      name: "13 copies of one main card",
+      main: oneCard("OGN-004", 13),
+      side: [],
+      champion: undefined,
+    },
+    {
+      name: "40 copies of one main card (max)",
+      main: oneCard("OGN-004", 40),
+      side: [],
+      champion: undefined,
+    },
+    {
+      name: "sideboard with 4 copies",
+      main: oneCard("OGN-004", 2),
+      side: oneCard("OGN-050", 4),
+      champion: undefined,
+    },
+    {
+      name: "sideboard with 8 copies (max)",
+      main: oneCard("OGN-004", 2),
+      side: oneCard("OGN-050", 8),
+      champion: undefined,
+    },
+    {
+      name: "high copy count + runes together (flags preserved)",
+      main: [
+        { cardCode: "VEN-097", count: 20 },
+        { cardCode: "SFD-R02", count: 3 },
+        { cardCode: "UNL-R05a", count: 2 },
+        { cardCode: "OGN-007", count: 3 },
+        { cardCode: "OGN-013", count: 1 },
+      ],
+      side: [{ cardCode: "OGN-050", count: 4 }],
+      champion: undefined,
+    },
+    {
+      name: "high copy count + chosen champion",
+      main: [
+        { cardCode: "VEN-097", count: 25 },
+        { cardCode: "OGN-103", count: 3 },
+        { cardCode: "OGN-013", count: 2 },
+      ],
+      side: [{ cardCode: "OGN-050", count: 5 }],
+      champion: "OGN-103",
+    },
+    {
+      name: "realistic 40-card Spiderling deck",
+      main: [
+        { cardCode: "VEN-097", count: 19 },
+        { cardCode: "VEN-001", count: 3 },
+        { cardCode: "VEN-002", count: 3 },
+        { cardCode: "VEN-003", count: 3 },
+        { cardCode: "VEN-010", count: 2 },
+        { cardCode: "VEN-020", count: 1 },
+        { cardCode: "VEN-021", count: 1 },
+        { cardCode: "VEN-022", count: 1 },
+      ],
+      side: [
+        { cardCode: "VEN-050", count: 4 },
+        { cardCode: "VEN-051", count: 2 },
+      ],
+      champion: undefined,
+    },
+    {
+      name: "real card: 20x VEN-097 (VEN = set 5)",
+      main: oneCard("VEN-097", 20),
+      side: [],
+      champion: undefined,
+    },
+    {
+      name: "copy count crossing the varint boundary (128)",
+      main: oneCard("VEN-097", 128),
+      side: [],
+      champion: undefined,
+    },
+  ];
+  for (const c of cases) {
+    test(c.name, () => {
+      const code = getCodeFromDeck(c.main, c.side, c.champion);
+      assert.equal(versionOf(code), 5, "should be a v5 code");
+      const decoded = getDeckFromCode(code);
+      assert.deepEqual(shape(decoded), {
+        mainDeck: normDeck(c.main),
+        sideboard: normDeck(c.side),
+        champion: c.champion ?? null,
+      });
+    });
+  }
+
+  test("signedSuffix option is honored in v5", () => {
+    const main = [
+      { cardCode: "VEN-097", count: 15 },
+      { cardCode: "OGN-007*", count: 2 },
+    ];
+    const code = getCodeFromDeck(main);
+    const decoded = getDeckFromCode(code, { signedSuffix: "*" });
+    assert.ok(
+      decoded.mainDeck.some((c) => c.cardCode === "OGN-007*"),
+      "signed card should decode with the '*' suffix"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v5 prefix-bit optimization — all-normal decks drop the per-card flag byte.
+// ---------------------------------------------------------------------------
+test.describe("v5 prefix-bit optimization", () => {
+  test("all-normal high-copy deck sets the prefix bit to 0", () => {
+    const code = getCodeFromDeck(oneCard("VEN-097", 40));
+    assert.equal(versionOf(code), 5);
+    assert.equal(prefixBitOf(code), 0);
+  });
+  test("a deck with an SP card sets the prefix bit to 1", () => {
+    const code = getCodeFromDeck(oneCard("VEN-SP1", 13));
+    assert.equal(prefixBitOf(code), 1);
+  });
+  test("a high-copy deck that also has a rune sets the prefix bit to 1", () => {
+    const code = getCodeFromDeck([
+      { cardCode: "VEN-097", count: 20 },
+      { cardCode: "SFD-R02", count: 3 },
+    ]);
+    assert.equal(prefixBitOf(code), 1);
+  });
+  test("dropping the flags makes an all-normal high-copy code shorter", () => {
+    const allNormal = getCodeFromDeck([
+      { cardCode: "VEN-097", count: 20 },
+      { cardCode: "VEN-001", count: 3 },
+      { cardCode: "VEN-002", count: 3 },
+      { cardCode: "VEN-003", count: 3 },
+      { cardCode: "VEN-010", count: 2 },
+    ]);
+    // Identical set/variant grouping — only VEN-001 -> VEN-R01 (same VEN base
+    // group, same count) — so the length delta isolates the flag-byte cost:
+    // flipping the prefix bit to 1 adds one flag byte per card.
+    const withRune = getCodeFromDeck([
+      { cardCode: "VEN-097", count: 20 },
+      { cardCode: "VEN-R01", count: 3 },
+      { cardCode: "VEN-002", count: 3 },
+      { cardCode: "VEN-003", count: 3 },
+      { cardCode: "VEN-010", count: 2 },
+    ]);
+    assert.equal(prefixBitOf(allNormal), 0);
+    assert.equal(prefixBitOf(withRune), 1);
+    assert.ok(
+      allNormal.length < withRune.length,
+      `all-normal (${allNormal.length}) should be shorter than flagged (${withRune.length})`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SP (special) number prefix — third value (0x02) on the flag byte, v5.
+// ---------------------------------------------------------------------------
+test.describe("SP (special) number prefix", () => {
+  // Exact bytes locked against the independent sparse+SP oracle.
+  const oracle = [
+    { name: "VEN-SP1 x3", main: oneCard("VEN-SP1", 3), code: "CUAQCAYBAECQAAQBAAAA" },
+    { name: "VEN-SP1a x3", main: oneCard("VEN-SP1a", 3), code: "CUAQCAYBAECQCAQBAAAA" },
+    {
+      name: "mixed 001/SP1/SP2 x3",
+      main: [
+        { cardCode: "VEN-001", count: 3 },
+        { cardCode: "VEN-SP1", count: 3 },
+        { cardCode: "VEN-SP2", count: 3 },
+      ],
+      code: "CUAQCAYBAMCQAAABAIAQEAQAAA",
+    },
+  ];
+  for (const v of oracle) {
+    test(`${v.name} matches the oracle string and is v5`, () => {
+      const code = getCodeFromDeck(v.main);
+      assert.equal(code, v.code);
+      assert.equal(versionOf(code), 5);
+    });
+  }
+
+  test("VEN-SP1 alone round-trips; emitted version is 5", () => {
+    const code = getCodeFromDeck(oneCard("VEN-SP1", 3));
+    assert.equal(versionOf(code), 5);
+    assert.deepEqual(getDeckFromCode(code).mainDeck, [
+      { cardCode: "VEN-SP1", count: 3 },
+    ]);
+  });
+
+  test("VEN-SP1a preserves the variant", () => {
+    const code = getCodeFromDeck(oneCard("VEN-SP1a", 2));
+    assert.deepEqual(getDeckFromCode(code).mainDeck, [
+      { cardCode: "VEN-SP1a", count: 2 },
+    ]);
+  });
+
+  test("VEN-SP01 normalises to VEN-SP1 (unpadded, intended)", () => {
+    const code = getCodeFromDeck(oneCard("VEN-SP01", 3));
+    assert.deepEqual(getDeckFromCode(code).mainDeck, [
+      { cardCode: "VEN-SP1", count: 3 },
+    ]);
+  });
+
+  test("normal + SP cards in the same group are all recovered", () => {
+    const main = [
+      { cardCode: "VEN-001", count: 3 },
+      { cardCode: "VEN-SP1", count: 3 },
+      { cardCode: "VEN-SP2", count: 3 },
+    ];
+    const decoded = getDeckFromCode(getCodeFromDeck(main));
+    assert.deepEqual(normDeck(decoded.mainDeck), normDeck(main));
+  });
+
+  test("SP card as chosen champion round-trips", () => {
+    const code = getCodeFromDeck(oneCard("VEN-097", 3), [], "VEN-SP1");
+    const decoded = getDeckFromCode(code);
+    assert.equal(versionOf(code), 5);
+    assert.equal(decoded.chosenChampion, "VEN-SP1");
+  });
+
+  test("SP card in the sideboard round-trips", () => {
+    const code = getCodeFromDeck(oneCard("VEN-001", 3), oneCard("VEN-SP1", 2));
+    const decoded = getDeckFromCode(code);
+    assert.equal(versionOf(code), 5);
+    assert.deepEqual(normDeck(decoded.sideboard), [
+      { cardCode: "VEN-SP1", count: 2 },
+    ]);
+  });
+
+  test("a rune AND an SP card together are both recovered, version 5", () => {
+    const main = [
+      { cardCode: "SFD-R02", count: 3 },
+      { cardCode: "VEN-SP1", count: 3 },
+      { cardCode: "VEN-001", count: 2 },
+    ];
+    const code = getCodeFromDeck(main);
+    assert.equal(versionOf(code), 5);
+    assert.deepEqual(normDeck(getDeckFromCode(code).mainDeck), normDeck(main));
+  });
+
+  test("lowercase 'sp' is rejected", () => {
+    assert.throws(
+      () => getCodeFromDeck(oneCard("VEN-sp1", 3)),
+      /Invalid card code/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (f) FORWARD-COMPAT GUARD — a code with a version byte beyond what we support
+//     must throw loudly, never silently misread.
+// ---------------------------------------------------------------------------
+test.describe("forward-compatibility guard", () => {
+  test("a version-6 code throws 'Unsupported version'", () => {
+    const future = bytesToBase32([(1 << 4) | 6]); // format 1, version 6
+    assert.throws(() => getDeckFromCode(future), /Unsupported version: 6/);
+  });
+  test("a version-15 code throws 'Unsupported version'", () => {
+    const future = bytesToBase32([(1 << 4) | 15]);
+    assert.throws(() => getDeckFromCode(future), /Unsupported version/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-loud decoding — unknown tokens throw rather than silently mis-decode.
+// ---------------------------------------------------------------------------
+test.describe("fail-loud decoding of unknown v5 tokens", () => {
+  test("a deck-level prefix bit > 1 throws", () => {
+    // format 1 / version 5, then prefix bit = 2 (only 0/1 are valid)
+    const bad = bytesToBase32([(1 << 4) | 5, 0x02]);
+    assert.throws(() => getDeckFromCode(bad), /Unsupported deck prefix flag/);
+  });
+  test("an unknown per-card prefix flag throws", () => {
+    // v5, prefix bit = 1 (flagged), main: 1 count(=3), 1 group, 1 card,
+    // set 5, variant 0, then an unknown flag 0x03 before the number.
+    const bad = bytesToBase32([
+      (1 << 4) | 5, 0x01, 1, 3, 1, 1, 5, 0, 0x03, 1,
+    ]);
+    assert.throws(() => getDeckFromCode(bad), /Unknown number-prefix flag/);
+  });
+});

--- a/test/deckCode.test.js
+++ b/test/deckCode.test.js
@@ -451,4 +451,35 @@ test.describe("fail-loud decoding of unknown v5 tokens", () => {
     ]);
     assert.throws(() => getDeckFromCode(bad), /Unknown number-prefix flag/);
   });
+  test("an unknown champion prefix flag throws (distinct from per-card)", () => {
+    // v5, prefix bit = 1, empty main + sideboard sections, then a present
+    // champion (set 5, variant 0) whose prefix flag is an unsupported 0x03.
+    const bad = bytesToBase32([
+      (1 << 4) | 5, 0x01, 0x00, 0x00, 0x01, 5, 0, 0x03, 1,
+    ]);
+    assert.throws(
+      () => getDeckFromCode(bad),
+      /Unknown number-prefix flag in champion/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Encode input validation — malformed counts are rejected, not silently wrapped.
+// ---------------------------------------------------------------------------
+test.describe("encode rejects invalid card counts", () => {
+  for (const bad of [0, -1, 2.5, NaN, Infinity]) {
+    test(`count ${bad} throws`, () => {
+      assert.throws(
+        () => getCodeFromDeck(oneCard("OGN-004", bad)),
+        /Count must be a positive integer/
+      );
+    });
+    test(`sideboard count ${bad} throws`, () => {
+      assert.throws(
+        () => getCodeFromDeck(oneCard("OGN-004", 1), oneCard("OGN-050", bad)),
+        /Count must be a positive integer/
+      );
+    });
+  }
 });

--- a/test/fixtures/golden.json
+++ b/test/fixtures/golden.json
@@ -1,0 +1,502 @@
+[
+  {
+    "name": "v3-basic (no runes, no sideboard, no champion)",
+    "input": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-004",
+          "count": 1
+        }
+      ],
+      "sideboard": []
+    },
+    "code": "CMAAAAAAAAAAAAAAAEAQAAAHAEAQAACZAEAQAAAEAAAAAAA",
+    "decoded": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-004",
+          "count": 1
+        }
+      ],
+      "sideboard": []
+    }
+  },
+  {
+    "name": "v3-sideboard (no runes, with sideboard, no champion)",
+    "input": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 7
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 5
+        },
+        {
+          "cardCode": "OGN-012",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-039",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-013",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-088",
+          "count": 1
+        }
+      ]
+    },
+    "code": "CMAAAAAAAAAQCAAAA4AACAIAABMQAAIBAAAAYAIBAAACOAIBAAAA2AABAEAAAFQBAEAAAWAA",
+    "decoded": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 7
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 5
+        },
+        {
+          "cardCode": "OGN-012",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-039",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-013",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-088",
+          "count": 1
+        }
+      ]
+    }
+  },
+  {
+    "name": "v3-champion (no runes, with sideboard, with champion)",
+    "input": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 7
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 5
+        },
+        {
+          "cardCode": "OGN-012",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-039",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-013",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-088",
+          "count": 1
+        }
+      ],
+      "chosenChampion": "OGN-012"
+    },
+    "code": "CMAAAAAAAAAQCAAAA4AACAIAABMQAAIBAAAAYAIBAAACOAIBAAAA2AABAEAAAFQBAEAAAWABAAAAY",
+    "decoded": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 7
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 5
+        },
+        {
+          "cardCode": "OGN-012",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-039",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-013",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-088",
+          "count": 1
+        }
+      ],
+      "chosenChampion": "OGN-012"
+    }
+  },
+  {
+    "name": "v4-runes (runes in main, sideboard, normal champion)",
+    "input": {
+      "mainDeck": [
+        {
+          "cardCode": "SFD-R02",
+          "count": 3
+        },
+        {
+          "cardCode": "UNL-R05a",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-007",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        }
+      ],
+      "chosenChampion": "OGN-007"
+    },
+    "code": "CQAAAAAAAAAAAAAAAIAQAAAAA4AQGAABAIAQCBABAECQCAIAAAAFSAABAEAAAAAWAAAQAAAAA4",
+    "decoded": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 3
+        },
+        {
+          "cardCode": "SFD-R02",
+          "count": 3
+        },
+        {
+          "cardCode": "UNL-R05a",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        }
+      ],
+      "chosenChampion": "OGN-007"
+    }
+  },
+  {
+    "name": "v4-rune-champion (rune main + rune champion)",
+    "input": {
+      "mainDeck": [
+        {
+          "cardCode": "SFD-R01",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-007",
+          "count": 3
+        }
+      ],
+      "sideboard": [],
+      "chosenChampion": "SFD-R01"
+    },
+    "code": "CQAAAAAAAAAAAAAAAEAQAAAAA4AQCAYAAEAQAAAAAAAQGAABAE",
+    "decoded": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 3
+        },
+        {
+          "cardCode": "SFD-R01",
+          "count": 2
+        }
+      ],
+      "sideboard": [],
+      "chosenChampion": "SFD-R01"
+    }
+  },
+  {
+    "name": "v3-large (README Kai'Sa deck, sideboard + champion)",
+    "input": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 7
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 5
+        },
+        {
+          "cardCode": "OGN-004",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-009",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-012",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-027",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-029",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-087",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-095",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-096",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-103",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-104",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-116",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-039",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-122",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-248",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-013",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-247",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-280",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-288",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-292",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-024",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-093",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-088",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-114",
+          "count": 1
+        }
+      ],
+      "chosenChampion": "OGN-103"
+    },
+    "code": "CMAAAAAAAAAQCAAAA4AACAIAABMQAAILAAAAICIMDMOVOX3AM5UHIAIDAAACO6XYAEAQKAAABX3QDGACUABKIAQAAEBQAAAWDBOQCAQAABMHEAIAABTQ",
+    "decoded": {
+      "mainDeck": [
+        {
+          "cardCode": "OGN-007",
+          "count": 7
+        },
+        {
+          "cardCode": "OGN-089",
+          "count": 5
+        },
+        {
+          "cardCode": "OGN-004",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-009",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-012",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-027",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-029",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-087",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-095",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-096",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-103",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-104",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-116",
+          "count": 3
+        },
+        {
+          "cardCode": "OGN-039",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-122",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-248",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-013",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-247",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-280",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-288",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-292",
+          "count": 1
+        }
+      ],
+      "sideboard": [
+        {
+          "cardCode": "OGN-022",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-024",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-093",
+          "count": 2
+        },
+        {
+          "cardCode": "OGN-088",
+          "count": 1
+        },
+        {
+          "cardCode": "OGN-114",
+          "count": 1
+        }
+      ],
+      "chosenChampion": "OGN-103"
+    }
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Introduces deck-code format **Version 5**, which lets a single card exceed the v1–4 copy-count ceilings (main 12 / sideboard 3) — e.g. **Spiderling** (`VEN-097`), whose rules text allows any number of copies — and adds the **`SP`** (special) card number-prefix (`VEN-SP1`, `VEN-SP1a`). v5 is emitted **only** for decks that need it: every normal deck still encodes as v3/v4 **byte-identically**, and all existing v1–v4 codes decode unchanged. A one-byte deck-level "prefix bit" keeps all-normal high-copy codes ~25% shorter (a 40-card Spiderling deck goes 133 → 100 chars). Also adds the project's first test suite and bumps the package to **1.4.0**.

## How to test

1. `npm install && npm test` — **63 tests pass**. Golden vectors lock v1–v4 backward compatibility; independent-oracle vectors lock the v5 wire format.
2. High copy count: `getCodeFromDeck([{ cardCode: "VEN-097", count: 20 }])` emits a v5 code that round-trips exactly through `getDeckFromCode`.
3. SP card: `getCodeFromDeck([{ cardCode: "VEN-SP1a", count: 2 }])` round-trips with the `a` variant preserved (`SP01` normalises to `SP1`).
4. Backward compat: a normal deck still encodes to the exact same string as 1.3.0 (v3/v4), and existing shared codes decode identically.
5. Fail-loud: a v5 code throws `Unsupported version: 5` on a ≤v4 decoder rather than mis-decoding.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Piltover-Archive/codesmith/RiftboundDeckCodes/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786694221&installation_id=134054296&pr_number=3&repository=Piltover-Archive%2FRiftboundDeckCodes&return_to=https%3A%2F%2Fgithub.com%2FPiltover-Archive%2FRiftboundDeckCodes%2Fpull%2F3&signature=4743c3769206af62b38a0031560e437d924165aa31c2f6ea6ee548e35d4a1906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Version 5 deck-code support for high copy counts and sparse encoding.
  - Added `SP` special-card number prefixes and flexible card-number formatting.
  - Added automatic version selection for decks requiring the new format.
  - Preserved compatibility with decoding Version 1–4 deck codes.

- **Bug Fixes**
  - Invalid or unknown encoding flags now fail safely instead of being silently misread.

- **Documentation**
  - Updated README and changelog with Version 5 behavior, compatibility details, and limits.

- **Tests**
  - Added comprehensive coverage for legacy compatibility, Version 5 encoding, special cards, and round-trip decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->